### PR TITLE
Fixed two documentation links

### DIFF
--- a/docs/get-started/security.mdx
+++ b/docs/get-started/security.mdx
@@ -7,7 +7,7 @@ import Hint from 'react-admonitions'
 
 ## Escaping
 
-See the page on [HTML-Escaping](syntax/auto-escaping) to learn how to guard against XSS attacks.
+See the page on [HTML-Escaping](../syntax/auto-escaping) to learn how to guard against XSS attacks.
 
 ## Code Injection
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -112,7 +112,7 @@ module.exports = {
           items: [
             {
               label: 'Docs',
-              to: 'docs/install',
+              to: 'docs/get-started/install',
             },
           ],
         },


### PR DESCRIPTION
**The Problem**
The following two links do not work and point to non-existent pages.
- [x] https://squirrelly.js.org/docs/get-started/security/ (HTML-Escaping)
- [x] https://squirrelly.js.org (Footer: Docs)

**The solution**
I have adapted the routes for these two links. Only minimal adjustments were necessary.

This should fix the error reported recently #24 